### PR TITLE
Redlink results refactoring

### DIFF
--- a/packages/dbs-ai/client/views/app/tabbar/externalSearch.html
+++ b/packages/dbs-ai/client/views/app/tabbar/externalSearch.html
@@ -11,7 +11,7 @@
 			{{/if}}
 		{{/let}}-->
 		{{#each messages}}
-			{{#if result}}
+			{{#if prepareResult}}
                 <div class="external-message">
 					{{#each filledQueryTemplate}}
                         <div class="query-template-wrapper {{state}} {{collapsed}}" data-template-index="{{@index}}">

--- a/packages/dbs-ai/client/views/app/tabbar/externalSearch.js
+++ b/packages/dbs-ai/client/views/app/tabbar/externalSearch.js
@@ -41,8 +41,8 @@ Template.dbsAI_externalSearch.helpers({
 		var knowledgebaseSuggestions = RocketChat.models.LivechatExternalMessage.findByRoomId(Template.currentData().rid,
 			{ts: -1}).fetch(), filledTemplate = [];
 		if (knowledgebaseSuggestions.length > 0) {
-			const tokens = knowledgebaseSuggestions[0].result.tokens;
-			$(knowledgebaseSuggestions[0].result.queryTemplates).each(function (indexTpl, queryTpl) {
+			const tokens = knowledgebaseSuggestions[0].prepareResult.tokens;
+			$(knowledgebaseSuggestions[0].prepareResult.queryTemplates).each(function (indexTpl, queryTpl) {
 				let extendedQueryTpl = queryTpl, filledQuerySlots = [];
 
 				/* tokens und queryTemplates mergen */
@@ -135,7 +135,7 @@ Template.dbsAI_externalSearch.events({
 	'click .knowledge-queries-wrapper .query-item a ': function (event, instance) {
 		const query = $(event.target).closest('.query-item');
 		let externalMsg = instance.externalMessages.get();
-		externalMsg.result.queryTemplates[query.data('templateIndex')].queries[query.data('queryIndex')].state = 'Confirmed';
+		externalMsg.prepareResult.queryTemplates[query.data('templateIndex')].queries[query.data('queryIndex')].state = 'Confirmed';
 		instance.externalMessages.set(externalMsg);
 		Meteor.call('updateKnowledgeProviderResult', instance.externalMessages.get(),(err) => {
 			if (err) {//TODO logging error
@@ -176,7 +176,7 @@ Template.dbsAI_externalSearch.events({
 	'click .query-template-tools-wrapper .icon-ok': function (event, instance) {
 		const query = $(event.target).closest('.query-template-wrapper');
 		let externalMsg = instance.externalMessages.get();
-		externalMsg.result.queryTemplates[query.data('templateIndex')].state = 'Confirmed';
+		externalMsg.prepareResult.queryTemplates[query.data('templateIndex')].state = 'Confirmed';
 		instance.externalMessages.set(externalMsg);
 		Meteor.call('updateKnowledgeProviderResult', instance.externalMessages.get(), (err) => {
 			if (err) {//TODO logging error
@@ -189,7 +189,7 @@ Template.dbsAI_externalSearch.events({
 	'click .query-template-tools-wrapper .icon-cancel': function (event, instance) {
 		const query = $(event.target).closest('.query-template-wrapper');
 		let externalMsg = instance.externalMessages.get();
-		externalMsg.result.queryTemplates[query.data('templateIndex')].state = 'Rejected';
+		externalMsg.prepareResult.queryTemplates[query.data('templateIndex')].state = 'Rejected';
 		instance.externalMessages.set(externalMsg);
 		Meteor.call('updateKnowledgeProviderResult', instance.externalMessages.get(), (err) => {
 			if (err) {//TODO logging error
@@ -252,11 +252,11 @@ Template.dbsAI_externalSearch.events({
 				saveValue
 		};
 
-		externalMsg.result.tokens.push(newToken);
-		externalMsg.result.queryTemplates[inputWrapper.data('parentTplIndex')].querySlots = _.map(externalMsg.result.queryTemplates[inputWrapper.data('parentTplIndex')].querySlots,
+		externalMsg.prepareResult.tokens.push(newToken);
+		externalMsg.prepareResult.queryTemplates[inputWrapper.data('parentTplIndex')].querySlots = _.map(externalMsg.prepareResult.queryTemplates[inputWrapper.data('parentTplIndex')].querySlots,
 			(query) => {
 				if (query.role === inputWrapper.data('slotRole')) {
-					query.tokenIndex = externalMsg.result.tokens.length - 1;
+					query.tokenIndex = externalMsg.prepareResult.tokens.length - 1;
 				}
 				return query;
 			});
@@ -288,14 +288,14 @@ Template.dbsAI_externalSearch.events({
 			templateIndex = field.attr('data-parent-tpl-index'),
 			slotRole = field.attr('data-slot-role');
 		let externalMsg = instance.externalMessages.get();
-		externalMsg.result.queryTemplates[templateIndex].querySlots = _.map(externalMsg.result.queryTemplates[templateIndex].querySlots,
+		externalMsg.prepareResult.queryTemplates[templateIndex].querySlots = _.map(externalMsg.prepareResult.queryTemplates[templateIndex].querySlots,
 			(query) => {
 				if (query.role === slotRole) {
 					query.tokenIndex = -1;
 				}
 				return query;
 			});
-		externalMsg.result.tokens[field.attr('data-token-index')].state = "Rejected";
+		externalMsg.prepareResult.tokens[field.attr('data-token-index')].state = "Rejected";
 		instance.externalMessages.set(externalMsg);
 		Meteor.call('updateKnowledgeProviderResult', instance.externalMessages.get(), (err) => {
 			instance.$(".knowledge-input-wrapper.active").removeClass("active");
@@ -310,10 +310,10 @@ Template.dbsAI_externalSearch.events({
 	'click .knowledge-base-tooltip .chat-item:not(.disabled)': function (event, inst) {
 		event.preventDefault();
 		const rlData = _.first(RocketChat.models.LivechatExternalMessage.findByRoomId(inst.roomId, {ts: -1}).fetch());
-		if (rlData && rlData.result) {
+		if (rlData && rlData.prepareResult) {
 			const input = inst.$(event.target).closest('.field-with-label'),
 				slotRole = input.attr('data-slot-role');
-			const qSlot = _.find(rlData.result.queryTemplates[input.attr('data-parent-tpl-index')].querySlots, (slot) => {
+			const qSlot = _.find(rlData.prepareResult.queryTemplates[input.attr('data-parent-tpl-index')].querySlots, (slot) => {
 				return slot.role == slotRole;
 			});
 			if (qSlot && qSlot.inquiryMessage) {
@@ -338,7 +338,7 @@ Template.dbsAI_externalSearch.events({
 		}
 		changeBtn.addClass("spinner");
 		let externalMsg = instance.externalMessages.get();
-		externalMsg.result.queryTemplates[left.data('parentTplIndex')].querySlots = _.map(externalMsg.result.queryTemplates[left.data('parentTplIndex')].querySlots,
+		externalMsg.prepareResult.queryTemplates[left.data('parentTplIndex')].querySlots = _.map(externalMsg.prepareResult.queryTemplates[left.data('parentTplIndex')].querySlots,
 			(query) => {
 				if (query.tokenIndex === leftTokenIndex) {
 					query.tokenIndex = rightTokenIndex;

--- a/packages/dbs-ai/client/views/app/tabbar/redlinkInlineResult.html
+++ b/packages/dbs-ai/client/views/app/tabbar/redlinkInlineResult.html
@@ -75,27 +75,6 @@
 </template>
 
 <!--Assistify-specific result templates-->
-<template name="redlinkInlineResult_conversation">
-    <div class="result-item-wrapper {{classExpanded}}">
-        <div class="query-preview-result-title clearfix">
-            <span class="result-title-wrapper">{{{originQuestion}}}</span>
-            <span class="icon-wrapper">
-					{{#if result.link}}<a href="{{result.link}}" target="_blank"><i
-                            class="icon-link-ext"></i></a>
-					{{/if}}
-                <span class="js-toggle-result-preview-expanded icon-up-open"></span>
-			</span>
-        </div>
-        <div class="query-preview-result-body">
-			<ul class="conversationMessages">
-			{{#each message in subsequentCommunication}}
-				{{> inlineResultMessage message=message}}
-			{{/each}}
-        </ul>
-
-		</div>
-    </div>
-</template>
 
 <template name="inlineResultMessage">
 	<li class="conversationMessage"><span class="{{getOriginatorClass message}}">{{{message.content}}}</span></li>
@@ -118,7 +97,7 @@
     </div>
 </template>
 
-<template name="redlinkInlineResult_Hasso_MLT">
+<template name="redlinkInlineResult_Hasso">
 	<div class="result-item-wrapper {{classExpanded}}">
 		<div class="query-preview-result-title clearfix">
 			<span class="result-title-wrapper">{{getResultTitle}}</span>
@@ -136,18 +115,6 @@
 				{{/each}}
 			</ul>
 
-		</div>
-	</div>
-</template>
-
-<template name="redlinkInlineResult_Hasso_Search">
-	<div class="result-item-wrapper {{classExpanded}}">
-		<div class="query-preview-result-title clearfix">
-			<span class="result-title-wrapper">{{{result.content}}}</span>
-			<span class="icon-wrapper">
-				<a href="{{result.link}}" target="_blank"><i class="icon-link-ext"></i></a>
-				<span class="js-toggle-result-preview-expanded icon-up-open"></span>
-			</span>
 		</div>
 	</div>
 </template>

--- a/packages/dbs-ai/client/views/app/tabbar/redlinkInlineResult.js
+++ b/packages/dbs-ai/client/views/app/tabbar/redlinkInlineResult.js
@@ -20,10 +20,10 @@ Template.redlinkInlineResult.helpers({
 				templateSuffix = "VKL_community";
 				break;
 			case 'Hasso-MLT':
-				templateSuffix = "Hasso_MLT";
+				templateSuffix = "Hasso";
 				break;
 			case 'Hasso-Search':
-				templateSuffix = "Hasso_Search";
+				templateSuffix = "Hasso";
 				break;
 			default:
 				if (!!Template['redlinkInlineResult_' + instance.data.result.creator]) {
@@ -120,53 +120,13 @@ Template.inlineResultMessage.helpers({
 	}
 });
 
-
-Template.redlinkInlineResult_conversation.helpers({
-	classExpanded(){
-		const instance = Template.instance();
-		return instance.state.get('expanded') ? 'expanded' : 'collapsed';
-	},
-	originQuestion(){
-		const instance = Template.instance();
-		return instance.data.result.messages[0].text;
-	},
-	latestResponse(){
-		const instance = Template.instance();
-		return instance.data.result.messages.filter((message)=>message.origin === 'provider').pop().text;
-	},
-
-	subsequentCommunication(){
-		const instance = Template.instance();
-		return instance.data.result.messages.slice(1);
-	}
-});
-
-Template.redlinkInlineResult_conversation.events({
-	'click .result-item-wrapper .js-toggle-result-preview-expanded': function (event, instance) {
-		const current = instance.state.get('expanded');
-		instance.state.set('expanded', !current);
-	}
-});
-
-Template.redlinkInlineResult_conversation.onCreated(function () {
-	const instance = this;
-
-	let transformedSnippet = instance.data.result.snippet;
-
-	this.state = new ReactiveDict();
-	this.state.setDefault({
-		expanded: false
-	});
-});
-
-
-Template.redlinkInlineResult_Hasso_MLT.events({
+Template.redlinkInlineResult_Hasso.events({
 	'click .result-item-wrapper .js-toggle-result-preview-expanded': function (event, instance) {
 		const current = instance.state.get('expanded');
 		instance.state.set('expanded', !current);
 	}});
 
-Template.redlinkInlineResult_Hasso_MLT.helpers({
+Template.redlinkInlineResult_Hasso.helpers({
 	classExpanded(){
 		const instance = Template.instance();
 		return instance.state.get('expanded') ? 'expanded' : 'collapsed';
@@ -181,26 +141,26 @@ Template.redlinkInlineResult_Hasso_MLT.helpers({
 	},
 	originQuestion(){
 		const instance = Template.instance();
-		if(instance.state.get('conversation')){
+		if(instance.state.get('conversation') && instance.state.get('conversationLoaded')){
 			return instance.state.get('conversation').messages[0].content;
 		}
 	},
 	latestResponse(){
 		const instance = Template.instance();
-		if(instance.state.get('conversation')){
+		if(instance.state.get('conversation') && instance.state.get('conversationLoaded')){
 			return instance.state.get('conversation').messages.filter((message) => message.user && message.user.displayName === 'Provider').pop().text;
 		}
 	},
 
 	subsequentCommunication(){
 		const instance = Template.instance();
-		if(instance.state.get('conversation')) {
+		if(instance.state.get('conversation') && instance.state.get('conversationLoaded')) {
 			return instance.state.get('conversation').messages.slice(1);
 		}
 	}
 });
 
-Template.redlinkInlineResult_Hasso_MLT.onCreated(function (){
+Template.redlinkInlineResult_Hasso.onCreated(function (){
 	let instance = this;
 
 	this.state = new ReactiveDict();
@@ -226,6 +186,5 @@ Template.redlinkInlineResult_Hasso_MLT.onCreated(function (){
 		}
 
 	});
-	// transform the result into a form which can be used by the generic communication template
 
 });

--- a/packages/dbs-ai/server/lib/Redlink.js
+++ b/packages/dbs-ai/server/lib/Redlink.js
@@ -16,7 +16,7 @@ class RedlinkAdapter {
 
 	createRedlinkStub(rid, latestKnowledgeProviderResult) {
 		const latestRedlinkResult = (latestKnowledgeProviderResult && latestKnowledgeProviderResult.knowledgeProvider === 'redlink')
-			? latestKnowledgeProviderResult.result
+			? latestKnowledgeProviderResult.prepareResult
 			: {};
 		return {
 			id: latestRedlinkResult.id ? latestRedlinkResult.id : rid,
@@ -38,7 +38,7 @@ class RedlinkAdapter {
 			// therefore we need to validate we're operating with a Redlink-result
 
 			analyzedUntil = latestKnowledgeProviderResult.originMessage ? latestKnowledgeProviderResult.originMessage.ts : 0;
-			conversation = latestKnowledgeProviderResult.result.messages ? latestKnowledgeProviderResult.result.messages : [];
+			conversation = latestKnowledgeProviderResult.prepareResult.messages ? latestKnowledgeProviderResult.prepareResult.messages : [];
 		}
 
 		const room = RocketChat.models.Rooms.findOneById(rid);
@@ -60,7 +60,7 @@ class RedlinkAdapter {
 		try {
 			SystemLogger.debug("sending update to redlinkk with: " + JSON.stringify(modifiedRedlinkResult));
 			let options = this.options;
-			options.data = modifiedRedlinkResult.result;
+			options.data = modifiedRedlinkResult.prepareResult;
 			const responseRedlinkQuery = HTTP.post(this.properties.url + '/query', options);
 			SystemLogger.debug("recieved update to redlinkk with: " + JSON.stringify(responseRedlinkQuery));
 			RocketChat.models.LivechatExternalMessage.update(
@@ -118,7 +118,7 @@ class RedlinkAdapter {
 					rid: message.rid,
 					knowledgeProvider: "redlink",
 					originMessage: {_id: message._id, ts: message.ts},
-					result: _postprocessPrepare(responseRedlinkPrepare.data),
+					prepareResult: _postprocessPrepare(responseRedlinkPrepare.data),
 					ts: new Date()
 				});
 
@@ -176,10 +176,10 @@ class RedlinkAdapter {
 				this.options.data = this.options;
 
 				options.data = {
-						messages: latestKnowledgeProviderResult.result.messagescl,
-						tokens: latestKnowledgeProviderResult.result.tokens,
-						queryTemplates: _preprocessTemplates(latestKnowledgeProviderResult.result.queryTemplates),
-						context: latestKnowledgeProviderResult.result.context
+						messages: latestKnowledgeProviderResult.prepareResult.messagescl,
+						tokens: latestKnowledgeProviderResult.prepareResult.tokens,
+						queryTemplates: _preprocessTemplates(latestKnowledgeProviderResult.prepareResult.queryTemplates),
+						context: latestKnowledgeProviderResult.prepareResult.context
 					};
 
 


### PR DESCRIPTION
- results from redlink-prepare-call now stored in external messages collection as `prepareResult` (previously `result` which was misleading in subsequent usages (compared to inline-results). No migration has been implemented, as there's no productive data for assistify yet.
- inline results for Hasso-MLT and Hasso-Search now utilize the same Blaze-template
