### PR TITLE
add configuration parameter for Assistify Widgets posting behaviour

### DIFF
--- a/packages/assistify/config.js
+++ b/packages/assistify/config.js
@@ -76,6 +76,19 @@ Meteor.startup(()=>{
 		i18nLabel: 'DBS_AI_Redlink_Domain'
 	});
 
+	RocketChat.settings.add('Assistify_AI_Widget_Posting_Type', '', {
+		type: 'select',
+		group: 'Assistify',
+		section: 'Knowledge_Base',
+		values: [
+			{ key: 'suggestText', i18nLabel: 'Assistify_AI_Widget_Posting_Type_SuggestText'},
+			{ key: 'postText', i18nLabel: 'Assistify_AI_Widget_Posting_Type_PostText'},
+			{ key: 'postRichText', i18nLabel: 'Assistify_AI_Widget_Posting_Type_PostRichText'}
+		],
+		public: true,
+		i18nLabel: 'Assistify_AI_Widget_Posting_Type'
+	});
+
 	RocketChat.settings.add('Assistify_AI_DBSearch_Suffix', '', {
 		type: 'code',
 		multiline: true,

--- a/packages/dbs-ai/client/views/app/tabbar/smarti.js
+++ b/packages/dbs-ai/client/views/app/tabbar/smarti.js
@@ -45,12 +45,18 @@ Template.dbsAI_smarti.onRendered(function() {
 			var WEBSOCKET_URL =
 				"ws" + RocketChat.settings.get('Site_Url').substring(4) + "websocket/";
 
+			var WIDGET_POSTING_TYPE = RocketChat.settings.get('Assistify_AI_Widget_Posting_Type') || 'postRichText';
+
+			console.log(WIDGET_POSTING_TYPE, RocketChat.settings.get('Assistify_AI_Widget_Posting_Type'));
 
 			self.smarti = new window.SmartiWidget(self.find('.external-message'), {
 				socketEndpoint: WEBSOCKET_URL,
 				smartiEndpoint: DBS_AI_Redlink_URL,
 				channel: self.data.rid,
-				inputCssSelector:'.autogrow-shadow'
+				postings: {
+					type: WIDGET_POSTING_TYPE,
+					cssInputSelector: '.message-form-text.input-message'
+				}
 			});
 		}
 	}

--- a/packages/rocketchat-i18n/i18n/dbsAI.de.i18n.yml
+++ b/packages/rocketchat-i18n/i18n/dbsAI.de.i18n.yml
@@ -63,6 +63,10 @@ DBS_AI_Redlink_Auth_Token: Basic-Auth Token
 DBS_AI_Redlink_Hook_Token: Token für eingende Nachrichten
 DBS_AI_Redlink_Domain: Domäne für Nachrichten
 Assistify_AI_DBSearch_Suffix: Eigener Such-Suffix
+Assistify_AI_Widget_Posting_Type: Posting-Verhalten des Widgets
+Assistify_AI_Widget_Posting_Type_SuggestText: Text vorschlagen
+Assistify_AI_Widget_Posting_Type_PostText: Text posten
+Assistify_AI_Widget_Posting_Type_PostRichText: RichText posten
 similar_to: Ähnliches zu
 similar_requests: Ähnliche Anfragen
 Link_provided: Ich habe hier eine ähnliche Konversation gefunden

--- a/packages/rocketchat-i18n/i18n/dbsAI.en.i18n.yml
+++ b/packages/rocketchat-i18n/i18n/dbsAI.en.i18n.yml
@@ -59,6 +59,10 @@ DBS_AI_Redlink_Auth_Token: Basic-Auth token
 DBS_AI_Redlink_Hook_Token: Token for incoming Messages
 DBS_AI_Redlink_Domain: Domain for messages
 Assistify_AI_DBSearch_Suffix: Custom search suffix
+Assistify_AI_Widget_Posting_Type: Widget posting behaviour
+Assistify_AI_Widget_Posting_Type_SuggestText: suggest text
+Assistify_AI_Widget_Posting_Type_PostText: post text
+Assistify_AI_Widget_Posting_Type_PostRichText: post rich text
 similar_to: Similar to
 similar_requests: Similar requests
 Link_provided: Similar question at


### PR DESCRIPTION
Hi @mrsimpson and @ruKurz 
This adds an additonal configuration parameter that is used at assistify widget creation. It defines if a click in the widget triggers a post with text, a post with rich text or just suggests text in the inout field. It fits to the current smarti release candidate, https://github.com/redlink-gmbh/smarti/tree/smarti-0.2.0-RC2.